### PR TITLE
Fix bugs in scientific notation

### DIFF
--- a/src/grammar/lexer.rs
+++ b/src/grammar/lexer.rs
@@ -423,7 +423,7 @@ impl<'input> Iterator for Lexer<'input> {
             static ref ID: Regex = Regex::new(r"^([a-z][A-Za-z0-9_]*)").unwrap();
             static ref INTEGER: Regex = Regex::new(r"^([1-9]+[0-9]*|0)").unwrap();
             static ref REAL: Regex =
-                Regex::new(r"^([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([eE][+-]?[0-9])?").unwrap();
+                Regex::new(r"^([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([eE][+-]?([0-9]+))?").unwrap();
             static ref SYMBOL: Regex = Regex::new(r"^(->|==|//|[+\-\*/\^\[\]\{\}\(\);,])").unwrap();
         }
 


### PR DESCRIPTION
Hi, I'm not sure if this repository is actively maintained, but as a current user, I would like to fix some bugs.
 
It seems that real numbers with scientific notation are not handled properly.
I fixed
- lexer to read scientific notations with multi digit exponents
- parser to convert scientific notation string representation into f64

Please let me know if you have any suggestions.